### PR TITLE
Add caching modules to 8.x

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -19,6 +19,10 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys E3036906AD9F30807351F
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd intl mbstring mcrypt mysql pdo_mysql pdo_pgsql pgsql zip
 
+# PECL extensions
+RUN pecl install APCu-beta \
+	&& docker-php-ext-enable apcu
+
 RUN a2enmod rewrite
 
 ENV OWNCLOUD_VERSION 8.0.5

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
 	libicu-dev \
 	libjpeg-dev \
 	libmcrypt-dev \
+	libmemcached-dev \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
@@ -18,6 +19,10 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys E3036906AD9F30807351F
 # https://doc.owncloud.org/server/8.1/admin_manual/installation/source_installation.html#prerequisites
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd intl mbstring mcrypt mysql pdo_mysql pdo_pgsql pgsql zip
+
+# PECL extensions
+RUN pecl install APCu-beta redis memcached \
+	&& docker-php-ext-enable apcu redis memcached
 
 RUN a2enmod rewrite
 


### PR DESCRIPTION
Recommended for local caching is APCu, and memcached or redis to cache for multiple instances.

See docs for how to use it:
https://doc.owncloud.org/server/8.1/admin_manual/configuration_server/config_sample_php_parameters.html#memory-caching-backend-configuration

fixes #15 

Note: OwnCloud could utilize APCu, and memcached as fallback, I don't think need to add something there.
Note 2: APCu is still considered "beta", but still recommended by upstream. And even included in Debian (stable).
