### PR TITLE
Enable LDAP PHP extension in all versions

### DIFF
--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+	libldap2-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc
@@ -18,6 +19,10 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys E3036906AD9F30807351F
 # https://doc.owncloud.org/server/8.1/admin_manual/installation/source_installation.html#prerequisites
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd intl mbstring mcrypt mysql pdo_mysql pdo_pgsql pgsql zip
+
+# LDAP extension
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
+	&& docker-php-ext-install ldap
 
 RUN a2enmod rewrite
 

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+	libldap2-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc
@@ -19,6 +20,10 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys E3036906AD9F30807351F
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd intl mbstring mcrypt mysql pdo_mysql pdo_pgsql pgsql zip
 
+# LDAP extension
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
+	&& docker-php-ext-install ldap
+	
 RUN a2enmod rewrite
 
 ENV OWNCLOUD_VERSION 7.0.10

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+	libldap2-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc
@@ -18,6 +19,10 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys E3036906AD9F30807351F
 # https://doc.owncloud.org/server/8.1/admin_manual/installation/source_installation.html#prerequisites
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd intl mbstring mcrypt mysql pdo_mysql pdo_pgsql pgsql zip
+
+# LDAP extension
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
+	&& docker-php-ext-install ldap
 
 # PECL extensions
 RUN pecl install APCu-beta \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+	libldap2-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc
@@ -19,6 +20,10 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys E3036906AD9F30807351F
 # https://doc.owncloud.org/server/8.1/admin_manual/installation/source_installation.html#prerequisites
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd intl mbstring mcrypt mysql pdo_mysql pdo_pgsql pgsql zip
+
+# LDAP extension
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
+	&& docker-php-ext-install ldap
 
 # PECL extensions
 RUN pecl install APCu-beta redis memcached \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# About this Repo
+# owncloud
 
 This is the Git repo of the official Docker image for [owncloud](https://registry.hub.docker.com/_/owncloud/). See the
 Hub page for the full readme on how to use the Docker image and for information


### PR DESCRIPTION
We think that most organizations have LDAP installed and should be enabled by default.

Fixes #24
