### PR TITLE
Add ssmtp for sendmail email

### DIFF
--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+	ssmtp \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+        ssmtp \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc

--- a/8.0/apache/Dockerfile
+++ b/8.0/apache/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+        ssmtp \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc

--- a/8.0/fpm/Dockerfile
+++ b/8.0/fpm/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+        ssmtp \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc

--- a/8.1/apache/Dockerfile
+++ b/8.1/apache/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+        ssmtp \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc

--- a/8.1/fpm/Dockerfile
+++ b/8.1/fpm/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+        ssmtp \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc

--- a/8.2/apache/Dockerfile
+++ b/8.2/apache/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+        ssmtp \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc

--- a/8.2/fpm/Dockerfile
+++ b/8.2/fpm/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+        ssmtp \
 	&& rm -rf /var/lib/apt/lists/*
 
 #gpg key from https://owncloud.org/owncloud.asc


### PR DESCRIPTION
There is no sendmail installed.  This change adds ssmtp, a small, stand-alone sendmail.

By running the container with /etc/ssmtp/ssmtp.conf as a volume, the administrator can use a centralized configuration:  if the administrator's default mail gateway changes, he can update the host ssmtp.conf to reflect the change to all Docker containers using ssmtp.

ssmtp configuration file would look as below:

```
# SSMTP configuration so sendmail works
# relays to our internal server
root=postmaster
Mailhub=smtp.example.com
hostname=docker-01.example.com
FromLineOverride=YES
```
