### PR TITLE
Install APCu version 4 explicitly now that 5 is also "stable" and only supports PHP 7+

### DIFF
--- a/8.0/apache/Dockerfile
+++ b/8.0/apache/Dockerfile
@@ -31,7 +31,7 @@ RUN { \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # PECL extensions
-RUN pecl install APCu \
+RUN pecl install APCu-4.0.10 \
 	&& docker-php-ext-enable apcu
 
 RUN a2enmod rewrite

--- a/8.0/fpm/Dockerfile
+++ b/8.0/fpm/Dockerfile
@@ -31,7 +31,7 @@ RUN { \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # PECL extensions
-RUN pecl install APCu \
+RUN pecl install APCu-4.0.10 \
 	&& docker-php-ext-enable apcu
 
 ENV OWNCLOUD_VERSION 8.0.9

--- a/8.1/apache/Dockerfile
+++ b/8.1/apache/Dockerfile
@@ -32,7 +32,7 @@ RUN { \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # PECL extensions
-RUN pecl install APCu redis memcached \
+RUN pecl install APCu-4.0.10 redis memcached \
 	&& docker-php-ext-enable apcu redis memcached
 
 RUN a2enmod rewrite

--- a/8.1/fpm/Dockerfile
+++ b/8.1/fpm/Dockerfile
@@ -32,7 +32,7 @@ RUN { \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # PECL extensions
-RUN pecl install APCu redis memcached \
+RUN pecl install APCu-4.0.10 redis memcached \
 	&& docker-php-ext-enable apcu redis memcached
 
 ENV OWNCLOUD_VERSION 8.1.4

--- a/8.2/apache/Dockerfile
+++ b/8.2/apache/Dockerfile
@@ -32,7 +32,7 @@ RUN { \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # PECL extensions
-RUN pecl install APCu redis memcached \
+RUN pecl install APCu-4.0.10 redis memcached \
 	&& docker-php-ext-enable apcu redis memcached
 
 RUN a2enmod rewrite

--- a/8.2/fpm/Dockerfile
+++ b/8.2/fpm/Dockerfile
@@ -32,7 +32,7 @@ RUN { \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # PECL extensions
-RUN pecl install APCu redis memcached \
+RUN pecl install APCu-4.0.10 redis memcached \
 	&& docker-php-ext-enable apcu redis memcached
 
 ENV OWNCLOUD_VERSION 8.2.1


### PR DESCRIPTION
This fixes build failures thanks to APCu's dep change.
