### PR TITLE
make owncloud cli occ usable via docker exec

### DIFF
--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -42,7 +42,10 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& gpg --batch --verify owncloud.tar.bz2.asc owncloud.tar.bz2 \
 	&& rm -r "$GNUPGHOME" owncloud.tar.bz2.asc \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
-	&& rm owncloud.tar.bz2
+	&& rm owncloud.tar.bz2 \
+# make owncloud cli occ usable via docker exec
+	&& echo '#!/bin/bash\nsu www-data -s /bin/bash -c "php /var/www/html/occ $*"' > /usr/local/sbin/occ \
+	&& chmod +x /usr/local/sbin/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -40,7 +40,10 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& gpg --batch --verify owncloud.tar.bz2.asc owncloud.tar.bz2 \
 	&& rm -r "$GNUPGHOME" owncloud.tar.bz2.asc \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
-	&& rm owncloud.tar.bz2
+	&& rm owncloud.tar.bz2 \
+# make owncloud cli occ usable via docker exec
+	&& echo '#!/bin/bash\nsu www-data -s /bin/bash -c "php /var/www/html/occ $*"' > /usr/local/sbin/occ \
+	&& chmod +x /usr/local/sbin/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/8.0/apache/Dockerfile
+++ b/8.0/apache/Dockerfile
@@ -46,7 +46,10 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& gpg --batch --verify owncloud.tar.bz2.asc owncloud.tar.bz2 \
 	&& rm -r "$GNUPGHOME" owncloud.tar.bz2.asc \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
-	&& rm owncloud.tar.bz2
+	&& rm owncloud.tar.bz2 \
+# make owncloud cli occ usable via docker exec
+	&& echo '#!/bin/bash\nsu www-data -s /bin/bash -c "php /var/www/html/occ $*"' > /usr/local/sbin/occ \
+	&& chmod +x /usr/local/sbin/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/8.0/fpm/Dockerfile
+++ b/8.0/fpm/Dockerfile
@@ -44,7 +44,10 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& gpg --batch --verify owncloud.tar.bz2.asc owncloud.tar.bz2 \
 	&& rm -r "$GNUPGHOME" owncloud.tar.bz2.asc \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
-	&& rm owncloud.tar.bz2
+	&& rm owncloud.tar.bz2 \
+# make owncloud cli occ usable via docker exec
+	&& echo '#!/bin/bash\nsu www-data -s /bin/bash -c "php /var/www/html/occ $*"' > /usr/local/sbin/occ \
+	&& chmod +x /usr/local/sbin/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/8.1/apache/Dockerfile
+++ b/8.1/apache/Dockerfile
@@ -47,7 +47,10 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& gpg --batch --verify owncloud.tar.bz2.asc owncloud.tar.bz2 \
 	&& rm -r "$GNUPGHOME" owncloud.tar.bz2.asc \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
-	&& rm owncloud.tar.bz2
+	&& rm owncloud.tar.bz2 \
+# make owncloud cli occ usable via docker exec
+	&& echo '#!/bin/bash\nsu www-data -s /bin/bash -c "php /var/www/html/occ $*"' > /usr/local/sbin/occ \
+	&& chmod +x /usr/local/sbin/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/8.1/fpm/Dockerfile
+++ b/8.1/fpm/Dockerfile
@@ -45,7 +45,10 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& gpg --batch --verify owncloud.tar.bz2.asc owncloud.tar.bz2 \
 	&& rm -r "$GNUPGHOME" owncloud.tar.bz2.asc \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
-	&& rm owncloud.tar.bz2
+	&& rm owncloud.tar.bz2 \
+# make owncloud cli occ usable via docker exec
+	&& echo '#!/bin/bash\nsu www-data -s /bin/bash -c "php /var/www/html/occ $*"' > /usr/local/sbin/occ \
+	&& chmod +x /usr/local/sbin/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/8.2/apache/Dockerfile
+++ b/8.2/apache/Dockerfile
@@ -47,7 +47,10 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& gpg --batch --verify owncloud.tar.bz2.asc owncloud.tar.bz2 \
 	&& rm -r "$GNUPGHOME" owncloud.tar.bz2.asc \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
-	&& rm owncloud.tar.bz2
+	&& rm owncloud.tar.bz2 \
+# make owncloud cli occ usable via docker exec
+	&& echo '#!/bin/bash\nsu www-data -s /bin/bash -c "php /var/www/html/occ $*"' > /usr/local/sbin/occ \
+	&& chmod +x /usr/local/sbin/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/8.2/fpm/Dockerfile
+++ b/8.2/fpm/Dockerfile
@@ -45,7 +45,10 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& gpg --batch --verify owncloud.tar.bz2.asc owncloud.tar.bz2 \
 	&& rm -r "$GNUPGHOME" owncloud.tar.bz2.asc \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
-	&& rm owncloud.tar.bz2
+	&& rm owncloud.tar.bz2 \
+# make owncloud cli occ usable via docker exec
+	&& echo '#!/bin/bash\nsu www-data -s /bin/bash -c "php /var/www/html/occ $*"' > /usr/local/sbin/occ \
+	&& chmod +x /usr/local/sbin/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/9.0/apache/Dockerfile
+++ b/9.0/apache/Dockerfile
@@ -47,7 +47,10 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& gpg --batch --verify owncloud.tar.bz2.asc owncloud.tar.bz2 \
 	&& rm -r "$GNUPGHOME" owncloud.tar.bz2.asc \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
-	&& rm owncloud.tar.bz2
+	&& rm owncloud.tar.bz2 \
+# make owncloud cli occ usable via docker exec
+	&& echo '#!/bin/bash\nsu www-data -s /bin/bash -c "php /var/www/html/occ $*"' > /usr/local/sbin/occ \
+	&& chmod +x /usr/local/sbin/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/9.0/fpm/Dockerfile
+++ b/9.0/fpm/Dockerfile
@@ -45,7 +45,10 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& gpg --batch --verify owncloud.tar.bz2.asc owncloud.tar.bz2 \
 	&& rm -r "$GNUPGHOME" owncloud.tar.bz2.asc \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
-	&& rm owncloud.tar.bz2
+	&& rm owncloud.tar.bz2 \
+# make owncloud cli occ usable via docker exec
+	&& echo '#!/bin/bash\nsu www-data -s /bin/bash -c "php /var/www/html/occ $*"' > /usr/local/sbin/occ \
+	&& chmod +x /usr/local/sbin/occ
 
 COPY docker-entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
as mentioned in #67 .
it should be documented at the hub page?
example usage: `docker exec oc_container occ app:check calendar`
