### PR TITLE
Add smbclient (60MB)

### DIFF
--- a/9.1/apache/Dockerfile
+++ b/9.1/apache/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+	smbclient \
 	&& rm -rf /var/lib/apt/lists/*
 
 # https://doc.owncloud.org/server/8.1/admin_manual/installation/source_installation.html#prerequisites

--- a/9.1/fpm/Dockerfile
+++ b/9.1/fpm/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
 	libpng12-dev \
 	libpq-dev \
 	libxml2-dev \
+	smbclient \
 	&& rm -rf /var/lib/apt/lists/*
 
 # https://doc.owncloud.org/server/8.1/admin_manual/installation/source_installation.html#prerequisites


### PR DESCRIPTION
Not having SMB support in the image triggers a warning when viewing external storage options. SMB support is very important for on-prem deployments where the files are backed by a Windows server. The base image should really have this owncloud feature. Only applied change to 9.1.
