### PR TITLE
Add ownCloud 10.0, update to PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
   - VERSION=9.1 VARIANT=apache
   - VERSION=9.0 VARIANT=fpm
   - VERSION=9.0 VARIANT=apache
+  - VERSION=10.0 VARIANT=fpm
+  - VERSION=10.0 VARIANT=apache
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/10.0/apache/Dockerfile
+++ b/10.0/apache/Dockerfile
@@ -1,7 +1,7 @@
 # https://owncloud.com/minimum-product-requirements/ ("5.6 recommended")
 # https://doc.owncloud.org/server/10.0/admin_manual/installation/system_requirements.html ("PHP (5.6+ or 7.0+)")
 # https://doc.owncloud.org/server/9.0/admin_manual/installation/system_requirements.html ("PHP 7.0")
-FROM php:7.0-fpm
+FROM php:7.0-apache
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -32,6 +32,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 		echo 'opcache.enable_cli=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+RUN a2enmod rewrite
 
 # PECL extensions
 RUN set -ex \
@@ -40,7 +41,7 @@ RUN set -ex \
 	&& pecl install redis-3.1.2 \
 	&& docker-php-ext-enable apcu memcached redis
 
-ENV OWNCLOUD_VERSION 9.1.6
+ENV OWNCLOUD_VERSION 10.0.2
 VOLUME /var/www/html
 
 RUN curl -fsSL -o owncloud.tar.bz2 \
@@ -56,6 +57,5 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& rm owncloud.tar.bz2
 
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["php-fpm"]
+CMD ["apache2-foreground"]

--- a/10.0/apache/docker-entrypoint.sh
+++ b/10.0/apache/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ ! -e '/var/www/html/version.php' ]; then
+	tar cf - --one-file-system -C /usr/src/owncloud . | tar xf -
+	chown -R www-data /var/www/html
+fi
+
+exec "$@"

--- a/10.0/fpm/Dockerfile
+++ b/10.0/fpm/Dockerfile
@@ -40,7 +40,7 @@ RUN set -ex \
 	&& pecl install redis-3.1.2 \
 	&& docker-php-ext-enable apcu memcached redis
 
-ENV OWNCLOUD_VERSION 9.1.6
+ENV OWNCLOUD_VERSION 10.0.2
 VOLUME /var/www/html
 
 RUN curl -fsSL -o owncloud.tar.bz2 \
@@ -56,6 +56,5 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& rm owncloud.tar.bz2
 
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["php-fpm"]

--- a/10.0/fpm/docker-entrypoint.sh
+++ b/10.0/fpm/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ ! -e '/var/www/html/version.php' ]; then
+	tar cf - --one-file-system -C /usr/src/owncloud . | tar xf -
+	chown -R www-data /var/www/html
+fi
+
+exec "$@"

--- a/9.0/apache/Dockerfile
+++ b/9.0/apache/Dockerfile
@@ -1,23 +1,26 @@
-FROM php:5.6-apache
+# https://owncloud.com/minimum-product-requirements/ ("5.6 recommended")
+# https://doc.owncloud.org/server/10.0/admin_manual/installation/system_requirements.html ("PHP (5.6+ or 7.0+)")
+# https://doc.owncloud.org/server/9.0/admin_manual/installation/system_requirements.html ("PHP 7.0")
+FROM php:7.0-apache
 
-RUN apt-get update && apt-get install -y \
-	bzip2 \
-	libcurl4-openssl-dev \
-	libfreetype6-dev \
-	libicu-dev \
-	libjpeg-dev \
-	libldap2-dev \
-	libmcrypt-dev \
-	libmemcached-dev \
-	libpng12-dev \
-	libpq-dev \
-	libxml2-dev \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		bzip2 \
+		libcurl4-openssl-dev \
+		libfreetype6-dev \
+		libicu-dev \
+		libjpeg-dev \
+		libldap2-dev \
+		libmcrypt-dev \
+		libmemcached-dev \
+		libpng12-dev \
+		libpq-dev \
+		libxml2-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # https://doc.owncloud.org/server/8.1/admin_manual/installation/source_installation.html#prerequisites
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-	&& docker-php-ext-install exif gd intl ldap mbstring mcrypt mysql opcache pdo_mysql pdo_pgsql pgsql zip
+	&& docker-php-ext-install exif gd intl ldap mbstring mcrypt opcache pdo pdo_mysql pdo_pgsql pgsql zip
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -33,9 +36,9 @@ RUN a2enmod rewrite
 
 # PECL extensions
 RUN set -ex \
-	&& pecl install APCu-4.0.10 \
-	&& pecl install memcached-2.2.0 \
-	&& pecl install redis-2.2.8 \
+	&& pecl install APCu-5.1.8 \
+	&& pecl install memcached-3.0.3 \
+	&& pecl install redis-3.1.2 \
 	&& docker-php-ext-enable apcu memcached redis
 
 ENV OWNCLOUD_VERSION 9.0.10
@@ -53,7 +56,7 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
 	&& rm owncloud.tar.bz2
 
-COPY docker-entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/9.0/fpm/Dockerfile
+++ b/9.0/fpm/Dockerfile
@@ -1,23 +1,26 @@
-FROM php:5.6-fpm
+# https://owncloud.com/minimum-product-requirements/ ("5.6 recommended")
+# https://doc.owncloud.org/server/10.0/admin_manual/installation/system_requirements.html ("PHP (5.6+ or 7.0+)")
+# https://doc.owncloud.org/server/9.0/admin_manual/installation/system_requirements.html ("PHP 7.0")
+FROM php:7.0-fpm
 
-RUN apt-get update && apt-get install -y \
-	bzip2 \
-	libcurl4-openssl-dev \
-	libfreetype6-dev \
-	libicu-dev \
-	libjpeg-dev \
-	libldap2-dev \
-	libmcrypt-dev \
-	libmemcached-dev \
-	libpng12-dev \
-	libpq-dev \
-	libxml2-dev \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		bzip2 \
+		libcurl4-openssl-dev \
+		libfreetype6-dev \
+		libicu-dev \
+		libjpeg-dev \
+		libldap2-dev \
+		libmcrypt-dev \
+		libmemcached-dev \
+		libpng12-dev \
+		libpq-dev \
+		libxml2-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # https://doc.owncloud.org/server/8.1/admin_manual/installation/source_installation.html#prerequisites
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-	&& docker-php-ext-install exif gd intl ldap mbstring mcrypt mysql opcache pdo_mysql pdo_pgsql pgsql zip
+	&& docker-php-ext-install exif gd intl ldap mbstring mcrypt opcache pdo pdo_mysql pdo_pgsql pgsql zip
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -32,9 +35,9 @@ RUN { \
 
 # PECL extensions
 RUN set -ex \
-	&& pecl install APCu-4.0.10 \
-	&& pecl install memcached-2.2.0 \
-	&& pecl install redis-2.2.8 \
+	&& pecl install APCu-5.1.8 \
+	&& pecl install memcached-3.0.3 \
+	&& pecl install redis-3.1.2 \
 	&& docker-php-ext-enable apcu memcached redis
 
 ENV OWNCLOUD_VERSION 9.0.10
@@ -52,7 +55,7 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
 	&& rm owncloud.tar.bz2
 
-COPY docker-entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["php-fpm"]

--- a/9.1/apache/Dockerfile
+++ b/9.1/apache/Dockerfile
@@ -1,23 +1,26 @@
-FROM php:5.6-apache
+# https://owncloud.com/minimum-product-requirements/ ("5.6 recommended")
+# https://doc.owncloud.org/server/10.0/admin_manual/installation/system_requirements.html ("PHP (5.6+ or 7.0+)")
+# https://doc.owncloud.org/server/9.0/admin_manual/installation/system_requirements.html ("PHP 7.0")
+FROM php:7.0-apache
 
-RUN apt-get update && apt-get install -y \
-	bzip2 \
-	libcurl4-openssl-dev \
-	libfreetype6-dev \
-	libicu-dev \
-	libjpeg-dev \
-	libldap2-dev \
-	libmcrypt-dev \
-	libmemcached-dev \
-	libpng12-dev \
-	libpq-dev \
-	libxml2-dev \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		bzip2 \
+		libcurl4-openssl-dev \
+		libfreetype6-dev \
+		libicu-dev \
+		libjpeg-dev \
+		libldap2-dev \
+		libmcrypt-dev \
+		libmemcached-dev \
+		libpng12-dev \
+		libpq-dev \
+		libxml2-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # https://doc.owncloud.org/server/8.1/admin_manual/installation/source_installation.html#prerequisites
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-	&& docker-php-ext-install exif gd intl ldap mbstring mcrypt mysql opcache pdo_mysql pdo_pgsql pgsql zip
+	&& docker-php-ext-install exif gd intl ldap mbstring mcrypt opcache pdo pdo_mysql pdo_pgsql pgsql zip
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -33,9 +36,9 @@ RUN a2enmod rewrite
 
 # PECL extensions
 RUN set -ex \
-	&& pecl install APCu-4.0.10 \
-	&& pecl install memcached-2.2.0 \
-	&& pecl install redis-2.2.8 \
+	&& pecl install APCu-5.1.8 \
+	&& pecl install memcached-3.0.3 \
+	&& pecl install redis-3.1.2 \
 	&& docker-php-ext-enable apcu memcached redis
 
 ENV OWNCLOUD_VERSION 9.1.6
@@ -53,7 +56,7 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
 	&& rm owncloud.tar.bz2
 
-COPY docker-entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,23 +1,26 @@
-FROM php:5.6-%%VARIANT%%
+# https://owncloud.com/minimum-product-requirements/ ("5.6 recommended")
+# https://doc.owncloud.org/server/10.0/admin_manual/installation/system_requirements.html ("PHP (5.6+ or 7.0+)")
+# https://doc.owncloud.org/server/9.0/admin_manual/installation/system_requirements.html ("PHP 7.0")
+FROM php:7.0-%%VARIANT%%
 
-RUN apt-get update && apt-get install -y \
-	bzip2 \
-	libcurl4-openssl-dev \
-	libfreetype6-dev \
-	libicu-dev \
-	libjpeg-dev \
-	libldap2-dev \
-	libmcrypt-dev \
-	libmemcached-dev \
-	libpng12-dev \
-	libpq-dev \
-	libxml2-dev \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		bzip2 \
+		libcurl4-openssl-dev \
+		libfreetype6-dev \
+		libicu-dev \
+		libjpeg-dev \
+		libldap2-dev \
+		libmcrypt-dev \
+		libmemcached-dev \
+		libpng12-dev \
+		libpq-dev \
+		libxml2-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # https://doc.owncloud.org/server/8.1/admin_manual/installation/source_installation.html#prerequisites
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-	&& docker-php-ext-install exif gd intl ldap mbstring mcrypt mysql opcache pdo_mysql pdo_pgsql pgsql zip
+	&& docker-php-ext-install exif gd intl ldap mbstring mcrypt opcache pdo pdo_mysql pdo_pgsql pgsql zip
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -33,9 +36,9 @@ RUN a2enmod rewrite
 
 # PECL extensions
 RUN set -ex \
-	&& pecl install APCu-4.0.10 \
-	&& pecl install memcached-2.2.0 \
-	&& pecl install redis-2.2.8 \
+	&& pecl install APCu-5.1.8 \
+	&& pecl install memcached-3.0.3 \
+	&& pecl install redis-3.1.2 \
 	&& docker-php-ext-enable apcu memcached redis
 
 ENV OWNCLOUD_VERSION %%VERSION%%
@@ -53,7 +56,7 @@ RUN curl -fsSL -o owncloud.tar.bz2 \
 	&& tar -xjf owncloud.tar.bz2 -C /usr/src/ \
 	&& rm owncloud.tar.bz2
 
-COPY docker-entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,7 +2,8 @@
 set -eu
 
 declare -A aliases=(
-	[9.1]='9 latest'
+	[10.0]='10 latest'
+	[9.1]='9'
 )
 
 self="$(basename "$BASH_SOURCE")"
@@ -10,6 +11,9 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( */ )
 versions=( "${versions[@]%/}" )
+
+# sort version numbers with highest first
+IFS=$'\n'; versions=( $(echo "${versions[*]}" | sort -rV) ); unset IFS
 
 # get the most recent commit which modified any of "$@"
 fileCommit() {


### PR DESCRIPTION
See the following documents for why we should update to PHP 7 unilaterally:

- https://doc.owncloud.org/server/9.0/admin_manual/installation/system_requirements.html  
  ("PHP 7.0")
- https://doc.owncloud.org/server/9.1/admin_manual/installation/system_requirements.html  
  ("PHP (5.6+ or 7.0+)")
- https://doc.owncloud.org/server/10.0/admin_manual/installation/system_requirements.html  
  ("PHP (5.6+ or 7.0+)")

There's even a pretty solid argument for making at least 10.0 go straight to 7.1 instead (but that complicates the templates).