### PR TITLE
Bump to php 7.2 (which is strongly encouraged by owncloud)

### DIFF
--- a/10.0/apache/Dockerfile
+++ b/10.0/apache/Dockerfile
@@ -1,7 +1,10 @@
-# https://owncloud.com/minimum-product-requirements/ ("5.6 recommended")
-# https://doc.owncloud.org/server/10.0/admin_manual/installation/system_requirements.html ("PHP (5.6+ or 7.0+)")
-# https://doc.owncloud.org/server/9.0/admin_manual/installation/system_requirements.html ("PHP 7.0")
-FROM php:7.0-apache
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM php:7.2-apache
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -11,7 +14,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libicu-dev \
 		libjpeg-dev \
 		libldap2-dev \
-		libmcrypt-dev \
 		libmemcached-dev \
 		libpng-dev \
 		libpq-dev \
@@ -29,8 +31,6 @@ RUN set -ex; \
 		gd \
 		intl \
 		ldap \
-		mbstring \
-		mcrypt \
 		opcache \
 		pcntl \
 		pdo_mysql \

--- a/10.0/fpm/Dockerfile
+++ b/10.0/fpm/Dockerfile
@@ -1,7 +1,10 @@
-# https://owncloud.com/minimum-product-requirements/ ("5.6 recommended")
-# https://doc.owncloud.org/server/10.0/admin_manual/installation/system_requirements.html ("PHP (5.6+ or 7.0+)")
-# https://doc.owncloud.org/server/9.0/admin_manual/installation/system_requirements.html ("PHP 7.0")
-FROM php:7.0-fpm
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM php:7.2-fpm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -11,7 +14,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libicu-dev \
 		libjpeg-dev \
 		libldap2-dev \
-		libmcrypt-dev \
 		libmemcached-dev \
 		libpng-dev \
 		libpq-dev \
@@ -29,8 +31,6 @@ RUN set -ex; \
 		gd \
 		intl \
 		ldap \
-		mbstring \
-		mcrypt \
 		opcache \
 		pcntl \
 		pdo_mysql \

--- a/9.1/apache/Dockerfile
+++ b/9.1/apache/Dockerfile
@@ -1,6 +1,9 @@
-# https://owncloud.com/minimum-product-requirements/ ("5.6 recommended")
-# https://doc.owncloud.org/server/10.0/admin_manual/installation/system_requirements.html ("PHP (5.6+ or 7.0+)")
-# https://doc.owncloud.org/server/9.0/admin_manual/installation/system_requirements.html ("PHP 7.0")
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
 FROM php:7.0-apache
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -29,7 +32,6 @@ RUN set -ex; \
 		gd \
 		intl \
 		ldap \
-		mbstring \
 		mcrypt \
 		opcache \
 		pcntl \

--- a/9.1/fpm/Dockerfile
+++ b/9.1/fpm/Dockerfile
@@ -1,6 +1,9 @@
-# https://owncloud.com/minimum-product-requirements/ ("5.6 recommended")
-# https://doc.owncloud.org/server/10.0/admin_manual/installation/system_requirements.html ("PHP (5.6+ or 7.0+)")
-# https://doc.owncloud.org/server/9.0/admin_manual/installation/system_requirements.html ("PHP 7.0")
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
 FROM php:7.0-fpm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -29,7 +32,6 @@ RUN set -ex; \
 		gd \
 		intl \
 		ldap \
-		mbstring \
 		mcrypt \
 		opcache \
 		pcntl \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,7 +1,4 @@
-# https://owncloud.com/minimum-product-requirements/ ("5.6 recommended")
-# https://doc.owncloud.org/server/10.0/admin_manual/installation/system_requirements.html ("PHP (5.6+ or 7.0+)")
-# https://doc.owncloud.org/server/9.0/admin_manual/installation/system_requirements.html ("PHP 7.0")
-FROM php:7.0-%%VARIANT%%
+FROM php:%%VARIANT%%
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -29,7 +26,6 @@ RUN set -ex; \
 		gd \
 		intl \
 		ldap \
-		mbstring \
 		mcrypt \
 		opcache \
 		pcntl \


### PR DESCRIPTION
Also, drop some extra modules:
- `mcrypt` is no longer part of PHP core (https://secure.php.net/manual/en/migration71.deprecated.php)
- `mbstring` has been on by default since https://github.com/docker-library/php/pull/211

Fixes #106